### PR TITLE
Update Playback.cs

### DIFF
--- a/DryWetMidi/Devices/Playback/Playback.cs
+++ b/DryWetMidi/Devices/Playback/Playback.cs
@@ -67,7 +67,7 @@ namespace Melanchall.DryWetMidi.Devices
 
         private bool _disposed = false;
 
-        private bool[] channelEnabled = new bool[16] {  true, true, true, true, true, true, true, true,
+        private bool[] _channelEnabled = new bool[16] {  true, true, true, true, true, true, true, true,
                                                         true, true, true, true, true, true, true, true };
 
         #endregion
@@ -269,11 +269,14 @@ namespace Melanchall.DryWetMidi.Devices
         {
             get
             {
-                return channelEnabled;
+                return _channelEnabled;
             }
             set
             {
-                channelEnabled = value;
+                if (value.Length != 16)
+                    throw new Exception("Array-Length must be 16");
+
+                _channelEnabled = value;
             }
         }
 
@@ -713,7 +716,7 @@ namespace Melanchall.DryWetMidi.Devices
             {
                 int channel = ((NoteOnEvent)midiEvent).Channel;
 
-                if (!channelEnabled[channel])
+                if (!_channelEnabled[channel])
                     return;
             }
 

--- a/DryWetMidi/Devices/Playback/Playback.cs
+++ b/DryWetMidi/Devices/Playback/Playback.cs
@@ -67,6 +67,9 @@ namespace Melanchall.DryWetMidi.Devices
 
         private bool _disposed = false;
 
+        private bool[] channelEnabled = new bool[16] {  true, true, true, true, true, true, true, true,
+                                                        true, true, true, true, true, true, true, true };
+
         #endregion
 
         #region Constructor
@@ -258,6 +261,21 @@ namespace Melanchall.DryWetMidi.Devices
         public NoteCallback NoteCallback { get; set; }
 
         public EventCallback EventCallback { get; set; }
+
+        /// <summary>
+        /// Enable or Disable the 16 Midi-Channels while Playback
+        /// </summary>
+        public bool[] ChannelEnabled
+        {
+            get
+            {
+                return channelEnabled;
+            }
+            set
+            {
+                channelEnabled = value;
+            }
+        }
 
         #endregion
 
@@ -690,6 +708,15 @@ namespace Melanchall.DryWetMidi.Devices
 
         private void SendEvent(MidiEvent midiEvent)
         {
+            // Realization for muting midi-Channels
+            if (midiEvent is NoteOnEvent)
+            {
+                int channel = ((NoteOnEvent)midiEvent).Channel;
+
+                if (!channelEnabled[channel])
+                    return;
+            }
+
             OutputDevice?.SendEvent(midiEvent);
             OnEventPlayed(midiEvent);
         }


### PR DESCRIPTION
The logic and realization of mute/solo functionality of a midi-mixing console is a little bit tricky...
I think using an Array of bool is simpler than using a method to enable/disable a single channel.

E.G think about the "Solo" functionality: I expect, that if I use a channel "solo" - and then I remove the "Solo"-state, the combination of the enabled channels before are restored. That means a combination of 16 channels have to be restored - using an array for that is simple.

I also expect, that not only one channel can be used for "Solo" - it also should be possible to use several of them...
