### PR TITLE
Exposing NoteId and NoteIdUtilities; Fixing NoteId.Equals bug

### DIFF
--- a/DryWetMidi.Tests/Interaction/Utilities/NodeId/NoteIdTests.cs
+++ b/DryWetMidi.Tests/Interaction/Utilities/NodeId/NoteIdTests.cs
@@ -1,0 +1,98 @@
+﻿using Melanchall.DryWetMidi.Common;
+using Melanchall.DryWetMidi.Interaction;
+using NUnit.Framework;
+
+namespace Melanchall.DryWetMidi.Tests.Interaction
+{
+    [TestFixture]
+    public sealed class NoteIdTests
+    {
+        #region Test methods
+
+        #region Equals
+
+        [Test]
+        public void Equals_NullObject()
+        {
+            var noteId = new NoteId(new FourBitNumber(), new SevenBitNumber());
+            var isEqual = noteId.Equals(null);
+            Assert.IsFalse(isEqual);
+        }
+
+        [Test]
+        public void Equals_SameObject()
+        {
+            var noteId = new NoteId(new FourBitNumber(), new SevenBitNumber());
+            var isEqual = noteId.Equals(noteId);
+            Assert.IsTrue(isEqual);
+        }
+
+        [Test]
+        public void Equals_DifferentObjectType()
+        {
+            var noteId = new NoteId(new FourBitNumber(), new SevenBitNumber());
+            var obj = new object();
+            var isEqual = noteId.Equals(obj);
+            Assert.IsFalse(isEqual);
+        }
+
+        [Test]
+        public void Equals_SameValues()
+        {
+            var noteId = new NoteId(new FourBitNumber(1), new SevenBitNumber(2));
+            var obj = new NoteId(new FourBitNumber(1), new SevenBitNumber(2));
+            var isEqual = noteId.Equals(obj);
+            Assert.IsTrue(isEqual);
+        }
+
+        [Test]
+        public void Equals_DifferentChannelValues()
+        {
+            var noteId = new NoteId(new FourBitNumber(1), new SevenBitNumber(2));
+            var obj = new NoteId(new FourBitNumber(2), new SevenBitNumber(2));
+            var isEqual = noteId.Equals(obj);
+            Assert.IsFalse(isEqual);
+        }
+
+        [Test]
+        public void Equals_DifferentNoteNumberValues()
+        {
+            var noteId = new NoteId(new FourBitNumber(1), new SevenBitNumber(2));
+            var obj = new NoteId(new FourBitNumber(1), new SevenBitNumber(3));
+            var isEqual = noteId.Equals(obj);
+            Assert.IsFalse(isEqual);
+        }
+
+        #endregion
+
+        #region GetHashCode
+
+        [Test]
+        public void GetHashCode_Empty()
+        {
+            var noteId1 = new NoteId(new FourBitNumber(), new SevenBitNumber());
+            var noteId2 = new NoteId(new FourBitNumber(), new SevenBitNumber());
+            Assert.AreEqual(noteId1.GetHashCode(), noteId2.GetHashCode(), "Hash codes must be consistent.");
+        }
+
+        [Test]
+        public void GetHashCode_Same()
+        {
+            var noteId1 = new NoteId(new FourBitNumber(1), new SevenBitNumber(2));
+            var noteId2 = new NoteId(new FourBitNumber(1), new SevenBitNumber(2));
+            Assert.AreEqual(noteId1.GetHashCode(), noteId2.GetHashCode(), "Hash codes must be consistent.");
+        }
+
+        [Test]
+        public void GetHashCode_Different()
+        {
+            var noteId1 = new NoteId(new FourBitNumber(1), new SevenBitNumber(2));
+            var noteId2 = new NoteId(new FourBitNumber(2), new SevenBitNumber(1));
+            Assert.AreNotEqual(noteId1.GetHashCode(), noteId2.GetHashCode(), "Hash codes must be consistent.");
+        }
+
+        #endregion
+
+        #endregion
+    }
+}

--- a/DryWetMidi.Tests/Interaction/Utilities/NodeId/NoteIdTests.cs
+++ b/DryWetMidi.Tests/Interaction/Utilities/NodeId/NoteIdTests.cs
@@ -15,52 +15,46 @@ namespace Melanchall.DryWetMidi.Tests.Interaction
         public void Equals_NullObject()
         {
             var noteId = new NoteId(new FourBitNumber(), new SevenBitNumber());
-            var isEqual = noteId.Equals(null);
-            Assert.IsFalse(isEqual);
+            Assert.AreNotEqual(noteId, null, "A null and non-null object are equal.");
         }
 
         [Test]
         public void Equals_SameObject()
         {
             var noteId = new NoteId(new FourBitNumber(), new SevenBitNumber());
-            var isEqual = noteId.Equals(noteId);
-            Assert.IsTrue(isEqual);
+            Assert.AreEqual(noteId, noteId, "An object is not equal to itself.");
         }
 
         [Test]
         public void Equals_DifferentObjectType()
         {
-            var noteId = new NoteId(new FourBitNumber(), new SevenBitNumber());
-            var obj = new object();
-            var isEqual = noteId.Equals(obj);
-            Assert.IsFalse(isEqual);
+            var noteId1 = new NoteId(new FourBitNumber(), new SevenBitNumber());
+            var noteId2 = new object();
+            Assert.AreNotEqual(noteId1, noteId2, "Objects of different types are equal.");
         }
 
         [Test]
         public void Equals_SameValues()
         {
-            var noteId = new NoteId(new FourBitNumber(1), new SevenBitNumber(2));
-            var obj = new NoteId(new FourBitNumber(1), new SevenBitNumber(2));
-            var isEqual = noteId.Equals(obj);
-            Assert.IsTrue(isEqual);
+            var noteId1 = new NoteId(new FourBitNumber(1), new SevenBitNumber(2));
+            var noteId2 = new NoteId(new FourBitNumber(1), new SevenBitNumber(2));
+            Assert.AreEqual(noteId1, noteId2, "Identical objects are not equal.");
         }
 
         [Test]
         public void Equals_DifferentChannelValues()
         {
-            var noteId = new NoteId(new FourBitNumber(1), new SevenBitNumber(2));
-            var obj = new NoteId(new FourBitNumber(2), new SevenBitNumber(2));
-            var isEqual = noteId.Equals(obj);
-            Assert.IsFalse(isEqual);
+            var noteId1 = new NoteId(new FourBitNumber(1), new SevenBitNumber(2));
+            var noteId2 = new NoteId(new FourBitNumber(2), new SevenBitNumber(2));
+            Assert.AreNotEqual(noteId1, noteId2, "Objects with mismatched channel values are equal.");
         }
 
         [Test]
         public void Equals_DifferentNoteNumberValues()
         {
-            var noteId = new NoteId(new FourBitNumber(1), new SevenBitNumber(2));
-            var obj = new NoteId(new FourBitNumber(1), new SevenBitNumber(3));
-            var isEqual = noteId.Equals(obj);
-            Assert.IsFalse(isEqual);
+            var noteId1 = new NoteId(new FourBitNumber(1), new SevenBitNumber(2));
+            var noteId2 = new NoteId(new FourBitNumber(1), new SevenBitNumber(3));
+            Assert.AreNotEqual(noteId1, noteId2, "Objects with mismatched note number values are equal.");
         }
 
         #endregion
@@ -72,7 +66,7 @@ namespace Melanchall.DryWetMidi.Tests.Interaction
         {
             var noteId1 = new NoteId(new FourBitNumber(), new SevenBitNumber());
             var noteId2 = new NoteId(new FourBitNumber(), new SevenBitNumber());
-            Assert.AreEqual(noteId1.GetHashCode(), noteId2.GetHashCode(), "Hash codes must be consistent.");
+            Assert.AreEqual(noteId1.GetHashCode(), noteId2.GetHashCode(), "Hash codes for identical empty objects are different.");
         }
 
         [Test]
@@ -80,7 +74,7 @@ namespace Melanchall.DryWetMidi.Tests.Interaction
         {
             var noteId1 = new NoteId(new FourBitNumber(1), new SevenBitNumber(2));
             var noteId2 = new NoteId(new FourBitNumber(1), new SevenBitNumber(2));
-            Assert.AreEqual(noteId1.GetHashCode(), noteId2.GetHashCode(), "Hash codes must be consistent.");
+            Assert.AreEqual(noteId1.GetHashCode(), noteId2.GetHashCode(), "Hash codes for identical objects are different.");
         }
 
         [Test]
@@ -88,7 +82,7 @@ namespace Melanchall.DryWetMidi.Tests.Interaction
         {
             var noteId1 = new NoteId(new FourBitNumber(1), new SevenBitNumber(2));
             var noteId2 = new NoteId(new FourBitNumber(2), new SevenBitNumber(1));
-            Assert.AreNotEqual(noteId1.GetHashCode(), noteId2.GetHashCode(), "Hash codes must be consistent.");
+            Assert.AreNotEqual(noteId1.GetHashCode(), noteId2.GetHashCode(), "Hash codes for different objects are the same.");
         }
 
         #endregion

--- a/DryWetMidi.Tests/Interaction/Utilities/NodeId/NoteIdUtilitiesTests.cs
+++ b/DryWetMidi.Tests/Interaction/Utilities/NodeId/NoteIdUtilitiesTests.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using Melanchall.DryWetMidi.Common;
+using Melanchall.DryWetMidi.Core;
+using Melanchall.DryWetMidi.Interaction;
+using Melanchall.DryWetMidi.MusicTheory;
+using NUnit.Framework;
+using Note = Melanchall.DryWetMidi.Interaction.Note;
+
+namespace Melanchall.DryWetMidi.Tests.Interaction
+{
+    [TestFixture]
+    public sealed class NoteIdUtilitiesTests
+    {
+        #region Test methods
+
+        #region GetNoteId
+
+        [Test]
+        public void GetNoteId_Note_Null()
+        {
+            Note note = null;
+            Assert.Throws<ArgumentNullException>(() => NoteIdUtilities.GetNoteId(note));
+        }
+
+        [Test]
+        public void GetNoteId_Note_ValidEmpty()
+        {
+            var note = new Note(new NoteName(), 1);
+            var noteId = note.GetNoteId();
+            Assert.NotNull(noteId);
+            Assert.AreEqual(new FourBitNumber(0), noteId.Channel, "The NoteId Channel should match.");
+            Assert.AreEqual(new SevenBitNumber(24), noteId.NoteNumber, "The NoteId NoteNumber should match.");
+        }
+
+        [Test]
+        public void GetNoteId_Note_ValidSet()
+        {
+            var note = new Note(new SevenBitNumber(2))
+            {
+                Channel = new FourBitNumber(1)
+            };
+            var noteId = note.GetNoteId();
+            Assert.NotNull(noteId);
+            Assert.AreEqual(new FourBitNumber(1), noteId.Channel, "The NoteId Channel should match.");
+            Assert.AreEqual(new SevenBitNumber(2), noteId.NoteNumber, "The NoteId NoteNumber should match.");
+        }
+
+        [Test]
+        public void GetNoteId_NoteEvent_Null()
+        {
+            NoteOnEvent noteEvent = null;
+            Assert.Throws<ArgumentNullException>(() => NoteIdUtilities.GetNoteId(noteEvent));
+        }
+
+        [Test]
+        public void GetNoteId_NoteEvent_ValidEmpty()
+        {
+            var noteEvent = new NoteOnEvent();
+            var noteId = noteEvent.GetNoteId();
+            Assert.NotNull(noteId);
+            Assert.AreEqual(new FourBitNumber(0), noteId.Channel, "The NoteId Channel should match.");
+            Assert.AreEqual(new SevenBitNumber(0), noteId.NoteNumber, "The NoteId NoteNumber should match.");
+        }
+
+        [Test]
+        public void GetNoteId_NoteEvent_ValidSet()
+        {
+            var noteEvent = new NoteOnEvent
+            {
+                Channel = new FourBitNumber(1),
+                NoteNumber = new SevenBitNumber(2)
+            };
+            var noteId = noteEvent.GetNoteId();
+            Assert.NotNull(noteId);
+            Assert.AreEqual(new FourBitNumber(1), noteId.Channel, "The NoteId Channel should match.");
+            Assert.AreEqual(new SevenBitNumber(2), noteId.NoteNumber, "The NoteId NoteNumber should match.");
+        }
+
+        #endregion
+
+        #endregion
+    }
+}

--- a/DryWetMidi.Tests/Interaction/Utilities/NodeId/NoteIdUtilitiesTests.cs
+++ b/DryWetMidi.Tests/Interaction/Utilities/NodeId/NoteIdUtilitiesTests.cs
@@ -19,7 +19,9 @@ namespace Melanchall.DryWetMidi.Tests.Interaction
         public void GetNoteId_Note_Null()
         {
             Note note = null;
-            Assert.Throws<ArgumentNullException>(() => NoteIdUtilities.GetNoteId(note));
+            Assert.Throws<ArgumentNullException>(
+                () => NoteIdUtilities.GetNoteId(note),
+                "The method did not throw a NullReferenceException when passed a null reference.");
         }
 
         [Test]
@@ -27,9 +29,9 @@ namespace Melanchall.DryWetMidi.Tests.Interaction
         {
             var note = new Note(new NoteName(), 1);
             var noteId = note.GetNoteId();
-            Assert.NotNull(noteId);
-            Assert.AreEqual(new FourBitNumber(0), noteId.Channel, "The NoteId Channel should match.");
-            Assert.AreEqual(new SevenBitNumber(24), noteId.NoteNumber, "The NoteId NoteNumber should match.");
+            Assert.NotNull(noteId, "The NoteId is null.");
+            Assert.AreEqual(new FourBitNumber(0), noteId.Channel, "The NoteId Channel is not the expected value.");
+            Assert.AreEqual(new SevenBitNumber(24), noteId.NoteNumber, "The NoteId NoteNumber is not the expected value.");
         }
 
         [Test]
@@ -40,16 +42,18 @@ namespace Melanchall.DryWetMidi.Tests.Interaction
                 Channel = new FourBitNumber(1)
             };
             var noteId = note.GetNoteId();
-            Assert.NotNull(noteId);
-            Assert.AreEqual(new FourBitNumber(1), noteId.Channel, "The NoteId Channel should match.");
-            Assert.AreEqual(new SevenBitNumber(2), noteId.NoteNumber, "The NoteId NoteNumber should match.");
+            Assert.NotNull(noteId, "The NoteId is null.");
+            Assert.AreEqual(new FourBitNumber(1), noteId.Channel, "The NoteId Channel is not the expected value.");
+            Assert.AreEqual(new SevenBitNumber(2), noteId.NoteNumber, "The NoteId NoteNumber is not the expected value.");
         }
 
         [Test]
         public void GetNoteId_NoteEvent_Null()
         {
             NoteOnEvent noteEvent = null;
-            Assert.Throws<ArgumentNullException>(() => NoteIdUtilities.GetNoteId(noteEvent));
+            Assert.Throws<ArgumentNullException>(
+                () => NoteIdUtilities.GetNoteId(noteEvent),
+                "The method did not throw a NullReferenceException when passed a null reference.");
         }
 
         [Test]
@@ -57,9 +61,9 @@ namespace Melanchall.DryWetMidi.Tests.Interaction
         {
             var noteEvent = new NoteOnEvent();
             var noteId = noteEvent.GetNoteId();
-            Assert.NotNull(noteId);
-            Assert.AreEqual(new FourBitNumber(0), noteId.Channel, "The NoteId Channel should match.");
-            Assert.AreEqual(new SevenBitNumber(0), noteId.NoteNumber, "The NoteId NoteNumber should match.");
+            Assert.NotNull(noteId, "The NoteId is null.");
+            Assert.AreEqual(new FourBitNumber(0), noteId.Channel, "The NoteId Channel is not the expected value.");
+            Assert.AreEqual(new SevenBitNumber(0), noteId.NoteNumber, "The NoteId NoteNumber is not the expected value.");
         }
 
         [Test]
@@ -71,9 +75,9 @@ namespace Melanchall.DryWetMidi.Tests.Interaction
                 NoteNumber = new SevenBitNumber(2)
             };
             var noteId = noteEvent.GetNoteId();
-            Assert.NotNull(noteId);
-            Assert.AreEqual(new FourBitNumber(1), noteId.Channel, "The NoteId Channel should match.");
-            Assert.AreEqual(new SevenBitNumber(2), noteId.NoteNumber, "The NoteId NoteNumber should match.");
+            Assert.NotNull(noteId, "The NoteId is null.");
+            Assert.AreEqual(new FourBitNumber(1), noteId.Channel, "The NoteId Channel is not the expected value.");
+            Assert.AreEqual(new SevenBitNumber(2), noteId.NoteNumber, "The NoteId NoteNumber is not the expected value.");
         }
 
         #endregion

--- a/DryWetMidi/Interaction/Utilities/NoteId/NoteId.cs
+++ b/DryWetMidi/Interaction/Utilities/NoteId/NoteId.cs
@@ -2,10 +2,18 @@
 
 namespace Melanchall.DryWetMidi.Interaction
 {
-    internal sealed class NoteId
+    /// <summary>
+    /// A class representing the ID of a musical note.
+    /// </summary>
+    public sealed class NoteId
     {
         #region Constructor
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NoteId"/> class.
+        /// </summary>
+        /// <param name="channel">The audio channel associated with the musical note.</param>
+        /// <param name="noteNumber">The identification number associated with the musical note.</param>
         public NoteId(FourBitNumber channel, SevenBitNumber noteNumber)
         {
             Channel = channel;
@@ -16,27 +24,45 @@ namespace Melanchall.DryWetMidi.Interaction
 
         #region Properties
 
+        /// <summary>
+        /// Gets the audio channel associated with the musical note.
+        /// </summary>
         public FourBitNumber Channel { get; }
 
+        /// <summary>
+        /// Gets the identification number associated with the musical note.
+        /// </summary>
         public SevenBitNumber NoteNumber { get; }
 
         #endregion
 
         #region Overrides
 
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object.
+        /// </summary>
+        /// <param name="obj">The object against which to compare the current object.</param>
+        /// <returns><c>true</c> if the specified object is equal to the current object; <c>false</c> otherwise.</returns>
         public override bool Equals(object obj)
         {
+            if (ReferenceEquals(obj, null))
+                return false;
+
             if (ReferenceEquals(obj, this))
                 return true;
 
             var noteId = obj as NoteId;
-            if (ReferenceEquals(obj, null))
+            if (ReferenceEquals(noteId, null))
                 return false;
 
             return Channel == noteId.Channel &&
                    NoteNumber == noteId.NoteNumber;
         }
 
+        /// <summary>
+        /// Gets a hash code for the current object.
+        /// </summary>
+        /// <returns>A hash code for the current object.</returns>
         public override int GetHashCode()
         {
             unchecked

--- a/DryWetMidi/Interaction/Utilities/NoteId/NoteIdUtilities.cs
+++ b/DryWetMidi/Interaction/Utilities/NoteId/NoteIdUtilities.cs
@@ -1,18 +1,36 @@
-﻿using Melanchall.DryWetMidi.Core;
+﻿using Melanchall.DryWetMidi.Common;
+using Melanchall.DryWetMidi.Core;
 
 namespace Melanchall.DryWetMidi.Interaction
 {
-    internal static class NoteIdUtilities
+    /// <summary>
+    /// Utilities related to the IDs of musical notes.
+    /// </summary>
+    public static class NoteIdUtilities
     {
         #region Methods
 
+        /// <summary>
+        /// Gets the ID of the specified musical note.
+        /// </summary>
+        /// <param name="note">The musical note for which to get the ID.</param>
+        /// <returns>The ID of the specified musical note.</returns>
         public static NoteId GetNoteId(this Note note)
         {
+            ThrowIfArgument.IsNull(nameof(note), note);
+
             return new NoteId(note.Channel, note.NoteNumber);
         }
 
+        /// <summary>
+        /// Gets the ID of the specified musical note event.
+        /// </summary>
+        /// <param name="noteEvent">The musical note event for which to get the ID.</param>
+        /// <returns>The ID of the specified musical note event.</returns>
         public static NoteId GetNoteId(this NoteEvent noteEvent)
         {
+            ThrowIfArgument.IsNull(nameof(noteEvent), noteEvent);
+
             return new NoteId(noteEvent.Channel, noteEvent.NoteNumber);
         }
 

--- a/DryWetMidi/Interaction/Utilities/NoteId/NoteIdUtilities.cs
+++ b/DryWetMidi/Interaction/Utilities/NoteId/NoteIdUtilities.cs
@@ -1,4 +1,5 @@
-﻿using Melanchall.DryWetMidi.Common;
+﻿using System;
+using Melanchall.DryWetMidi.Common;
 using Melanchall.DryWetMidi.Core;
 
 namespace Melanchall.DryWetMidi.Interaction
@@ -15,6 +16,7 @@ namespace Melanchall.DryWetMidi.Interaction
         /// </summary>
         /// <param name="note">The musical note for which to get the ID.</param>
         /// <returns>The ID of the specified musical note.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="note"/> is null.</exception>
         public static NoteId GetNoteId(this Note note)
         {
             ThrowIfArgument.IsNull(nameof(note), note);
@@ -27,6 +29,7 @@ namespace Melanchall.DryWetMidi.Interaction
         /// </summary>
         /// <param name="noteEvent">The musical note event for which to get the ID.</param>
         /// <returns>The ID of the specified musical note event.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="noteEvent"/> is null.</exception>
         public static NoteId GetNoteId(this NoteEvent noteEvent)
         {
             ThrowIfArgument.IsNull(nameof(noteEvent), noteEvent);


### PR DESCRIPTION
Changing the access modifiers of the `NoteId` and `NoteIdUtilities` classes from `internal` to `public`, to enable external consumers to access these classes from their applications.

This change also includes a small fix for the `NoteId.Equals` method, which could theoretically incorrectly throw a `NullReferenceException` is certain cases.

The change also adds comments to the now-exposed methods and properties to address Visual Studio warnings. `null` checks have also been added for the parameters of the now public methods.