### PR TITLE
Exposing events in Note class

### DIFF
--- a/DryWetMidi.Tests/Interaction/Notes/NoteTests.cs
+++ b/DryWetMidi.Tests/Interaction/Notes/NoteTests.cs
@@ -130,16 +130,14 @@ namespace Melanchall.DryWetMidi.Tests.Interaction
         #region GetTimedNoteOnEvent
 
         [Test]
-        [Description("Check that a different clone of the event is return each time.")]
         public void GetTimedNoteOnEvent()
         {
             var note = new Note(new SevenBitNumber(1));
             var timedNoteOnEvent1 = note.GetTimedNoteOnEvent();
             var timedNoteOnEvent2 = note.GetTimedNoteOnEvent();
-
-            Assert.IsNotNull(timedNoteOnEvent1);
-            Assert.IsNotNull(timedNoteOnEvent2);
-            Assert.AreNotEqual(timedNoteOnEvent1, timedNoteOnEvent2, "Events must be cloned.");
+            Assert.IsNotNull(timedNoteOnEvent1, "1st event is null.");
+            Assert.IsNotNull(timedNoteOnEvent2, "2nd event is null.");
+            Assert.AreNotEqual(timedNoteOnEvent1, timedNoteOnEvent2, "Events have not been cloned.");
         }
 
         #endregion
@@ -147,16 +145,14 @@ namespace Melanchall.DryWetMidi.Tests.Interaction
         #region GetTimedNoteOffEvent
 
         [Test]
-        [Description("Check that a different clone of the event is return each time.")]
         public void GetTimedNoteOffEvent()
         {
             var note = new Note(new SevenBitNumber(1));
             var timedNoteOffEvent1 = note.GetTimedNoteOffEvent();
             var timedNoteOffEvent2 = note.GetTimedNoteOffEvent();
-
-            Assert.IsNotNull(timedNoteOffEvent1);
-            Assert.IsNotNull(timedNoteOffEvent2);
-            Assert.AreNotEqual(timedNoteOffEvent1, timedNoteOffEvent2, "Events must be cloned.");
+            Assert.IsNotNull(timedNoteOffEvent1, "1st event is null.");
+            Assert.IsNotNull(timedNoteOffEvent2, "2nd event is null.");
+            Assert.AreNotEqual(timedNoteOffEvent1, timedNoteOffEvent2, "Events have not been cloned.");
         }
 
         #endregion

--- a/DryWetMidi.Tests/Interaction/Notes/NoteTests.cs
+++ b/DryWetMidi.Tests/Interaction/Notes/NoteTests.cs
@@ -127,6 +127,40 @@ namespace Melanchall.DryWetMidi.Tests.Interaction
 
         #endregion
 
+        #region GetTimedNoteOnEvent
+
+        [Test]
+        [Description("Check that a different clone of the event is return each time.")]
+        public void GetTimedNoteOnEvent()
+        {
+            var note = new Note(new SevenBitNumber(1));
+            var timedNoteOnEvent1 = note.GetTimedNoteOnEvent();
+            var timedNoteOnEvent2 = note.GetTimedNoteOnEvent();
+
+            Assert.IsNotNull(timedNoteOnEvent1);
+            Assert.IsNotNull(timedNoteOnEvent2);
+            Assert.AreNotEqual(timedNoteOnEvent1, timedNoteOnEvent2, "Events must be cloned.");
+        }
+
+        #endregion
+
+        #region GetTimedNoteOffEvent
+
+        [Test]
+        [Description("Check that a different clone of the event is return each time.")]
+        public void GetTimedNoteOffEvent()
+        {
+            var note = new Note(new SevenBitNumber(1));
+            var timedNoteOffEvent1 = note.GetTimedNoteOffEvent();
+            var timedNoteOffEvent2 = note.GetTimedNoteOffEvent();
+
+            Assert.IsNotNull(timedNoteOffEvent1);
+            Assert.IsNotNull(timedNoteOffEvent2);
+            Assert.AreNotEqual(timedNoteOffEvent1, timedNoteOffEvent2, "Events must be cloned.");
+        }
+
+        #endregion
+
         #endregion
 
         #region Private methods

--- a/DryWetMidi/Interaction/Notes/Note.cs
+++ b/DryWetMidi/Interaction/Notes/Note.cs
@@ -238,6 +238,24 @@ namespace Melanchall.DryWetMidi.Interaction
         #region Methods
 
         /// <summary>
+        /// Gets the 'Note On' timed event of the current note.
+        /// </summary>
+        /// <returns>The 'Note On' timed event of the current note.</returns>
+        public TimedEvent GetTimedNoteOnEvent()
+        {
+            return TimedNoteOnEvent.Clone();
+        }
+
+        /// <summary>
+        /// Gets the 'Note Off' timed event of the current note.
+        /// </summary>
+        /// <returns>The 'Note Off' timed event of the current note.</returns>
+        public TimedEvent GetTimedNoteOffEvent()
+        {
+            return TimedNoteOffEvent.Clone();
+        }
+
+        /// <summary>
         /// Sets note name and octave for current <see cref="Note"/>.
         /// </summary>
         /// <param name="noteName">Name of the note.</param>


### PR DESCRIPTION
Adding `GetTimedNoteOnEvent` and `GetTimedNoteOffEvent` methods to the `Note` class, to allow external callers from other applications to gain access to the internal note processing events.

These methods avoid exposing the properties, to avoid problematic modification of the events by external callers. Moreover, the methods call the `Clone` methods for this reason.