### PR TITLE
BugFix: PatternUtilities.CombineInParallel last action moves back to previous time

### DIFF
--- a/DryWetMidi.Tests/Composing/PatternUtilities/PatternUtilitiesTests.CombineInParallel.cs
+++ b/DryWetMidi.Tests/Composing/PatternUtilities/PatternUtilitiesTests.CombineInParallel.cs
@@ -54,6 +54,42 @@ namespace Melanchall.DryWetMidi.Tests.Composing
             });
         }
 
+        /// <summary>
+        /// This test ensures that the final operation when combining patterns in parallel does not end with a move back to the previous time.
+        /// </summary>
+        [Test]
+        public void CombineInParallel_No_Final_Move()
+        {
+            var pattern1 = new PatternBuilder()
+                .Note(Notes.DSharp2)
+                .Build();
+
+            var noteLength = MusicalTimeSpan.Sixteenth;
+            var pattern2 = new PatternBuilder()
+                .SetNoteLength(noteLength)
+                .Note(Notes.A4)
+                .Note(Notes.ASharp4)
+                .Build();
+
+            var parallelPatterns = new[] { pattern1, pattern2 }.CombineInParallel();
+
+            var pattern3 = new PatternBuilder()
+                    .Note(Notes.C4)
+                    .Build();
+
+            var pattern = new[] { parallelPatterns, pattern3 }.CombineInSequence();
+
+            PatternTestUtilities.TestNotes(pattern, new[]
+            {
+                new NoteInfo(NoteName.DSharp, 2, null, PatternBuilder.DefaultNoteLength),
+
+                new NoteInfo(NoteName.A, 4, null, noteLength),
+                new NoteInfo(NoteName.ASharp, 4, noteLength, noteLength),
+
+                new NoteInfo(NoteName.C, 4, noteLength*2, PatternBuilder.DefaultNoteLength),
+            });
+        }
+
         #endregion
     }
 }

--- a/DryWetMidi.Tests/Composing/PatternUtilities/PatternUtilitiesTests.CombineInParallel.cs
+++ b/DryWetMidi.Tests/Composing/PatternUtilities/PatternUtilitiesTests.CombineInParallel.cs
@@ -73,11 +73,10 @@ namespace Melanchall.DryWetMidi.Tests.Composing
 
             var parallelPatterns = new[] { pattern1, pattern2 }.CombineInParallel();
 
-            var pattern3 = new PatternBuilder()
+            var pattern = new PatternBuilder()
+                    .Pattern(parallelPatterns)
                     .Note(Notes.C4)
                     .Build();
-
-            var pattern = new[] { parallelPatterns, pattern3 }.CombineInSequence();
 
             PatternTestUtilities.TestNotes(pattern, new[]
             {

--- a/DryWetMidi.Tests/Composing/PatternUtilities/PatternUtilitiesTests.CombineInParallel.cs
+++ b/DryWetMidi.Tests/Composing/PatternUtilities/PatternUtilitiesTests.CombineInParallel.cs
@@ -54,10 +54,8 @@ namespace Melanchall.DryWetMidi.Tests.Composing
             });
         }
 
-        /// <summary>
-        /// This test ensures that the final operation when combining patterns in parallel does not end with a move back to the previous time.
-        /// </summary>
         [Test]
+        [Description("This test ensures that the final operation when combining patterns in parallel does not end with a move back to the previous time.")]
         public void CombineInParallel_No_Final_Move()
         {
             var pattern1 = new PatternBuilder()
@@ -74,9 +72,9 @@ namespace Melanchall.DryWetMidi.Tests.Composing
             var parallelPatterns = new[] { pattern1, pattern2 }.CombineInParallel();
 
             var pattern = new PatternBuilder()
-                    .Pattern(parallelPatterns)
-                    .Note(Notes.C4) // <-- this note should play AFTER the end of the parallel patterns
-                    .Build();
+                .Pattern(parallelPatterns)
+                .Note(Notes.C4) // <-- this note should play AFTER the end of the parallel patterns
+                .Build();
 
             PatternTestUtilities.TestNotes(pattern, new[]
             {

--- a/DryWetMidi.Tests/Composing/PatternUtilities/PatternUtilitiesTests.CombineInParallel.cs
+++ b/DryWetMidi.Tests/Composing/PatternUtilities/PatternUtilitiesTests.CombineInParallel.cs
@@ -75,7 +75,7 @@ namespace Melanchall.DryWetMidi.Tests.Composing
 
             var pattern = new PatternBuilder()
                     .Pattern(parallelPatterns)
-                    .Note(Notes.C4)
+                    .Note(Notes.C4) // <-- this note should play AFTER the end of the parallel patterns
                     .Build();
 
             PatternTestUtilities.TestNotes(pattern, new[]
@@ -85,7 +85,7 @@ namespace Melanchall.DryWetMidi.Tests.Composing
                 new NoteInfo(NoteName.A, 4, null, noteLength),
                 new NoteInfo(NoteName.ASharp, 4, noteLength, noteLength),
 
-                new NoteInfo(NoteName.C, 4, noteLength*2, PatternBuilder.DefaultNoteLength),
+                new NoteInfo(NoteName.C, 4, noteLength * 2, PatternBuilder.DefaultNoteLength),
             });
         }
 

--- a/DryWetMidi/Composing/PatternUtilities.cs
+++ b/DryWetMidi/Composing/PatternUtilities.cs
@@ -278,9 +278,15 @@ namespace Melanchall.DryWetMidi.Composing
 
             var patternBuilder = new PatternBuilder();
 
-            foreach (var pattern in patterns.Where(p => p != null))
+            using (var enumerator = patterns.Where(p => p != null).GetEnumerator())
             {
-                patternBuilder.Pattern(pattern).MoveToPreviousTime();
+                if (enumerator.MoveNext())
+                {
+                    patternBuilder.Pattern(enumerator.Current);
+
+                    while (enumerator.MoveNext())
+                        patternBuilder.MoveToPreviousTime().Pattern(enumerator.Current);
+                }
             }
 
             return patternBuilder.Build();


### PR DESCRIPTION
I believe that the CombineInParallel should _not_ move back to the previous time on it's final iteration.