### PR TITLE
Add new total properties for MetricTimeSpan

### DIFF
--- a/DryWetMidi/Interaction/TimeSpan/Representations/MetricTimeSpan.cs
+++ b/DryWetMidi/Interaction/TimeSpan/Representations/MetricTimeSpan.cs
@@ -128,27 +128,27 @@ namespace Melanchall.DryWetMidi.Interaction
         public long TotalMicroseconds => _timeSpan.Ticks / TicksInMicrosecond;
 
         /// <summary>
-        /// Gets the value of the current <see cref="MetricTimeSpan"/> expressed in whole and fractional in milliseconds.
+        /// Gets the value of the current <see cref="MetricTimeSpan"/> expressed in whole and fractional milliseconds.
         /// </summary>
         public double TotalMilliseconds => _timeSpan.TotalMilliseconds;
 
         /// <summary>
-        /// Gets the value of the current <see cref="MetricTimeSpan"/> expressed in whole and fractional in seconds.
+        /// Gets the value of the current <see cref="MetricTimeSpan"/> expressed in whole and fractional seconds.
         /// </summary>
         public double TotalSeconds => _timeSpan.TotalSeconds;
 
         /// <summary>
-        /// Gets the value of the current <see cref="MetricTimeSpan"/> expressed in whole and fractional in minutes.
+        /// Gets the value of the current <see cref="MetricTimeSpan"/> expressed in whole and fractional minutes.
         /// </summary>
         public double TotalMinutes => _timeSpan.TotalMinutes;
 
         /// <summary>
-        /// Gets the value of the current <see cref="MetricTimeSpan"/> expressed in whole and fractional in hours.
+        /// Gets the value of the current <see cref="MetricTimeSpan"/> expressed in whole and fractional hours.
         /// </summary>
         public double TotalHours => _timeSpan.TotalHours;
         
         /// <summary>
-        /// Gets the value of the current <see cref="MetricTimeSpan"/> expressed in whole and fractional in hours.
+        /// Gets the value of the current <see cref="MetricTimeSpan"/> expressed in whole and fractional days.
         /// </summary>
         public double TotalDays => _timeSpan.TotalDays;
 

--- a/DryWetMidi/Interaction/TimeSpan/Representations/MetricTimeSpan.cs
+++ b/DryWetMidi/Interaction/TimeSpan/Representations/MetricTimeSpan.cs
@@ -128,24 +128,29 @@ namespace Melanchall.DryWetMidi.Interaction
         public long TotalMicroseconds => _timeSpan.Ticks / TicksInMicrosecond;
 
         /// <summary>
-        /// Gets the value of the current <see cref="MetricTimeSpan"/> expressed in milliseconds.
+        /// Gets the value of the current <see cref="MetricTimeSpan"/> expressed in whole and fractional in milliseconds.
         /// </summary>
-        public long TotalMilliseconds => TotalMicroseconds / 1000;
+        public double TotalMilliseconds => _timeSpan.TotalMilliseconds;
 
         /// <summary>
-        /// Gets the value of the current <see cref="MetricTimeSpan"/> expressed in seconds.
+        /// Gets the value of the current <see cref="MetricTimeSpan"/> expressed in whole and fractional in seconds.
         /// </summary>
-        public long TotalSeconds => TotalMilliseconds / 1000;
+        public double TotalSeconds => _timeSpan.TotalSeconds;
 
         /// <summary>
-        /// Gets the value of the current <see cref="MetricTimeSpan"/> expressed in minutes.
+        /// Gets the value of the current <see cref="MetricTimeSpan"/> expressed in whole and fractional in minutes.
         /// </summary>
-        public long TotalMinutes => TotalSeconds / 60;
+        public double TotalMinutes => _timeSpan.TotalMinutes;
 
         /// <summary>
-        /// Gets the value of the current <see cref="MetricTimeSpan"/> expressed in hours.
+        /// Gets the value of the current <see cref="MetricTimeSpan"/> expressed in whole and fractional in hours.
         /// </summary>
-        public long TotalHours => TotalMinutes / 60;
+        public double TotalHours => _timeSpan.TotalHours;
+        
+        /// <summary>
+        /// Gets the value of the current <see cref="MetricTimeSpan"/> expressed in whole and fractional in hours.
+        /// </summary>
+        public double TotalDays => _timeSpan.TotalDays;
 
         /// <summary>
         /// Gets the hours component of the time represented by the current <see cref="MetricTimeSpan"/>.

--- a/DryWetMidi/Interaction/TimeSpan/Representations/MetricTimeSpan.cs
+++ b/DryWetMidi/Interaction/TimeSpan/Representations/MetricTimeSpan.cs
@@ -128,6 +128,26 @@ namespace Melanchall.DryWetMidi.Interaction
         public long TotalMicroseconds => _timeSpan.Ticks / TicksInMicrosecond;
 
         /// <summary>
+        /// Gets the value of the current <see cref="MetricTimeSpan"/> expressed in milliseconds.
+        /// </summary>
+        public long TotalMilliseconds => TotalMicroseconds / 1000;
+
+        /// <summary>
+        /// Gets the value of the current <see cref="MetricTimeSpan"/> expressed in seconds.
+        /// </summary>
+        public long TotalSeconds => TotalMilliseconds / 1000;
+
+        /// <summary>
+        /// Gets the value of the current <see cref="MetricTimeSpan"/> expressed in minutes.
+        /// </summary>
+        public long TotalMinutes => TotalSeconds / 60;
+
+        /// <summary>
+        /// Gets the value of the current <see cref="MetricTimeSpan"/> expressed in hours.
+        /// </summary>
+        public long TotalHours => TotalMinutes / 60;
+
+        /// <summary>
         /// Gets the hours component of the time represented by the current <see cref="MetricTimeSpan"/>.
         /// </summary>
         public int Hours => _timeSpan.Hours;


### PR DESCRIPTION
Adds the following shortcut properties to `MetricTimeSpan`:
- `TotalMilliseconds`
- `TotalSeconds`
- `TotalMinutes`
- `TotalHours`
- `TotalDays`