### PR TITLE
Fix spelling

### DIFF
--- a/Docs/articles/devices/Devices-watcher.md
+++ b/Docs/articles/devices/Devices-watcher.md
@@ -93,7 +93,7 @@ namespace DwmExamples
 }
 ```
 
-The progrum will be crashed with:
+The program will be crashed with:
 
 ```text
 Removing device...

--- a/Docs/articles/devices/Overview.md
+++ b/Docs/articles/devices/Overview.md
@@ -25,4 +25,4 @@ To understand what is an input and an output device in DryWetMIDI take a look at
 
 So, as you can see, although a MIDI port is _MIDI IN_ for MIDI device, it will be an **output device** in DryWetMIDI because your application will **send MIDI data to** this port. _MIDI OUT_ of MIDI device will be an **input device** in DryWetMIDI because a program will **receive MIDI data from** the port.
 
-If some error occured during sending or receiving a MIDI event, the [ErrorOccurred](xref:Melanchall.DryWetMidi.Multimedia.MidiDevice.ErrorOccurred) event will be fired holding an exception caused the error.
+If some error occurred during sending or receiving a MIDI event, the [ErrorOccurred](xref:Melanchall.DryWetMidi.Multimedia.MidiDevice.ErrorOccurred) event will be fired holding an exception caused the error.

--- a/Docs/articles/devices/Virtual-device.md
+++ b/Docs/articles/devices/Virtual-device.md
@@ -7,7 +7,7 @@ uid: a_dev_virtual
 > [!IMPORTANT]
 > Virtual devices API is a platform-specific one so please refer to the [Supported OS](xref:a_develop_supported_os) article to learn more. For Windows you can use products like [virtualMIDI SDK](https://www.tobias-erichsen.de/software/virtualmidi/virtualmidi-sdk.html) or similar to work with virtual MIDI ports programmatically. Be careful with license of these products.
 
-With DryWetMIDI you can programmatically create virtual MIDI devices with the specified name using [VirtualDevice.Create](xref:Melanchall.DryWetMidi.Multimedia.VirtualDevice.Create(System.String)) method. In fact virtual device is an [input](xref:a_dev_input) and an [output](xref:a_dev_output) devices paired together in a way that any MIDI event sent to the output device will be immediately transfered back from the virtual device and can be received by an application from its input subdevice.
+With DryWetMIDI you can programmatically create virtual MIDI devices with the specified name using [VirtualDevice.Create](xref:Melanchall.DryWetMidi.Multimedia.VirtualDevice.Create(System.String)) method. In fact virtual device is an [input](xref:a_dev_input) and an [output](xref:a_dev_output) devices paired together in a way that any MIDI event sent to the output device will be immediately transferred back from the virtual device and can be received by an application from its input subdevice.
 
 Thus we have [loopback](https://en.wikipedia.org/wiki/Loopback) device here. Loopback device is useful, for example, as intermediate layer between an application and some software synthesizer. In this case:
 

--- a/Docs/articles/file-reading-writing/MIDI-file-writing.md
+++ b/Docs/articles/file-reading-writing/MIDI-file-writing.md
@@ -10,7 +10,7 @@ The simplest code for MIDI file writing is:
 file.Write("Some great song.mid");
 ```
 
-If file with this name already exist, you'll get an excption. To overwrite existing file pass `true` to `overwriteFile` parameter:
+If file with this name already exist, you'll get an exception. To overwrite existing file pass `true` to `overwriteFile` parameter:
 
 ```csharp
 file.Write("Some great song.mid", overwriteFile: true);

--- a/Docs/articles/high-level-managing/Getting-objects.md
+++ b/Docs/articles/high-level-managing/Getting-objects.md
@@ -430,7 +430,7 @@ Getting notes and timed events...
 
 So all note events that build up a note were turned into instances of [Note](xref:Melanchall.DryWetMidi.Interaction.Note), and all remaining events (including "free" _Note On_ one) were returned as instances of [TimedEvent](xref:Melanchall.DryWetMidi.Interaction.TimedEvent).
 
-We can go futher and collect all possible chords, notes and timed events:
+We can go further and collect all possible chords, notes and timed events:
 
 ```csharp
 Console.WriteLine("Getting chords, notes and timed events...");

--- a/Docs/articles/playback/Common-problems.md
+++ b/Docs/articles/playback/Common-problems.md
@@ -6,7 +6,7 @@ uid: a_playback_commonproblems
 
 ## Playback doesn't produce sound or events logs
 
-Make sure an instance of [Playback](xref:Melanchall.DryWetMidi.Multimedia.Playback) class is holded by class field, global variable or something else that can live longer that method where you instantiate `Playback`. In this case
+Make sure an instance of [Playback](xref:Melanchall.DryWetMidi.Multimedia.Playback) class is held by class field, global variable or something else that can live longer that method where you instantiate `Playback`. In this case
 
 ```csharp
 private void StartPlayback()
@@ -20,7 +20,7 @@ private void StartPlayback()
 
 ## Unity hangs or crash on entering Play mode second time
 
-By default `Playback` uses [HighPrecisionTickGenerator](xref:Melanchall.DryWetMidi.Multimedia.HighPrecisionTickGenerator) tick generator (see [Tick generator](Tick-generator.md) article to learn more). `HighPrecisionTickGenerator` uses WinAPI methods by P/Invoke wich causes troubles in Unity environment. You may notice that Unity hangs forever if you hit Play button second time. Unfortunately it seems the [problem](https://issuetracker.unity3d.com/issues/editor-freezes-when-updating-a-nativearray-on-the-net-4-dot-x-scripting-runtime-and-entering-play-mode-a-second-time) won't be fixed. Answer of Unity tech support:
+By default `Playback` uses [HighPrecisionTickGenerator](xref:Melanchall.DryWetMidi.Multimedia.HighPrecisionTickGenerator) tick generator (see [Tick generator](Tick-generator.md) article to learn more). `HighPrecisionTickGenerator` uses WinAPI methods by P/Invoke which causes troubles in Unity environment. You may notice that Unity hangs forever if you hit Play button second time. Unfortunately it seems the [problem](https://issuetracker.unity3d.com/issues/editor-freezes-when-updating-a-nativearray-on-the-net-4-dot-x-scripting-runtime-and-entering-play-mode-a-second-time) won't be fixed. Answer of Unity tech support:
 
 > Unfortunately, that is correct = we will not be able to fix this in the near term because it probably requires rewriting of internal threading functionality, which might introduce new issues. The main case has been tagged for a revisit internally, but it will probably be months until the case is re-valuated again.
 

--- a/Docs/articles/tools/Quantizer.md
+++ b/Docs/articles/tools/Quantizer.md
@@ -50,7 +50,7 @@ Also if one side (start or end) of an object is fixed, there is a chance that th
 
 You can derive from the [Quantizer](xref:Melanchall.DryWetMidi.Tools.Quantizer) class and override its [OnObjectQuantizing](xref:Melanchall.DryWetMidi.Tools.Quantizer.OnObjectQuantizing*) method. Inside this method you can decide whether quantizing for an object should be performed or not and if yes, what new time should be set.
 
-Information about what quantizer is going to do with an object is passed via `quantizedTime` parameter of [QuantizedTime](xref:Melanchall.DryWetMidi.Tools.QuantizedTime) type. Image below shows what information is holded within this class:
+Information about what quantizer is going to do with an object is passed via `quantizedTime` parameter of [QuantizedTime](xref:Melanchall.DryWetMidi.Tools.QuantizedTime) type. Image below shows what information is held within this class:
 
 ![QuantizedTime](images/Quantizer/QuantizedTime.png)
 
@@ -105,13 +105,13 @@ class Program
 
             .StepForward(MusicalTimeSpan.Sixteenth)
             .Note("A5")
-                
+
             .StepForward(MusicalTimeSpan.Quarter)
             .Note("B2")
-                
+
             .StepForward(new MusicalTimeSpan(3, 8))
             .Note("C#3")
-                
+
             .Build()
             .ToFile(tempoMap);
 

--- a/Docs/articles/tools/Resizer.md
+++ b/Docs/articles/tools/Resizer.md
@@ -12,7 +12,7 @@ So as you can see the tool treats all passed objects as a single group and then 
 
 ![Objects resizing in detail](images/Resizer/ResizeObjectsGroup-Details.png)
 
-You use [ResizeObjectsGroup](xref:Melanchall.DryWetMidi.Tools.Resizer.ResizeObjectsGroup*) methods to stretch or shrink a group of [timed objects](xref:Melanchall.DryWetMidi.Interaction.ITimedObject). You can size a group either to the specified new length or by ratio. Ratio means that all distances from the start of a group will be multiplied by this value. So if ratio of `2` is specified, an objects group will be enlarged by 2 times. And `0.5` means the group will be shrinked by 2 times (new length will be half (`0.5`) of the original one).
+You use [ResizeObjectsGroup](xref:Melanchall.DryWetMidi.Tools.Resizer.ResizeObjectsGroup*) methods to stretch or shrink a group of [timed objects](xref:Melanchall.DryWetMidi.Interaction.ITimedObject). You can size a group either to the specified new length or by ratio. Ratio means that all distances from the start of a group will be multiplied by this value. So if ratio of `2` is specified, an objects group will be enlarged by 2 times. And `0.5` means the group will be shrunk by 2 times (new length will be half (`0.5`) of the original one).
 
 There also [Resize](xref:Melanchall.DryWetMidi.Tools.Resizer.Resize*) methods to resize [MidiFile](xref:Melanchall.DryWetMidi.Core.MidiFile) or [TrackChunk](xref:Melanchall.DryWetMidi.Core.TrackChunk).
 

--- a/DryWetMidi.Tests/Multimedia/Playback/PlaybackTests.Metadata.cs
+++ b/DryWetMidi.Tests/Multimedia/Playback/PlaybackTests.Metadata.cs
@@ -93,11 +93,11 @@ namespace Melanchall.DryWetMidi.Tests.Multimedia
             var timedEvents = GetTimedEvents(midiFile);
             var outputDevice = new OutputDeviceWithMetadataRegistration();
 
-            var trachChunkIndices = new List<int>();
+            var trackChunkIndices = new List<int>();
 
             using (var playback = new PlaybackWithMetadataRegistration(timedEvents, midiFile.GetTempoMap(), outputDevice))
             {
-                playback.EventPlayed += (_, e) => trachChunkIndices.Add((int)e.Metadata);
+                playback.EventPlayed += (_, e) => trackChunkIndices.Add((int)e.Metadata);
 
                 playback.Start();
 
@@ -108,8 +108,8 @@ namespace Melanchall.DryWetMidi.Tests.Multimedia
 
             CollectionAssert.AreEqual(
                 new[] { 0, 1, 0, 1, 0, 1, 0, 1 },
-                trachChunkIndices,
-                "Invalid track chunk indicies registered.");
+                trackChunkIndices,
+                "Invalid track chunk indices registered.");
         }
 
         [Retry(RetriesNumber)]

--- a/DryWetMidi.Tests/Multimedia/Playback/PlaybackTests.TickGenerator.cs
+++ b/DryWetMidi.Tests/Multimedia/Playback/PlaybackTests.TickGenerator.cs
@@ -68,7 +68,7 @@ namespace Melanchall.DryWetMidi.Tests.Multimedia
 
         #endregion
 
-        #region Test mthods
+        #region Test methods
 
         [Retry(RetriesNumber)]
         [Test]

--- a/DryWetMidi/MusicTheory/Interval/Interval.cs
+++ b/DryWetMidi/MusicTheory/Interval/Interval.cs
@@ -561,7 +561,7 @@ namespace Melanchall.DryWetMidi.MusicTheory
         /// <param name="interval">The interval to shrink.</param>
         /// <param name="divisor">The number to divide the <paramref name="interval"/> by.</param>
         /// <returns>The <see cref="Interval"/> which is the <paramref name="interval"/>
-        /// shrinked by the <paramref name="divisor"/>.</returns>
+        /// shrunk by the <paramref name="divisor"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="interval"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="divisor"/> is zero.</exception>
         public static Interval operator /(Interval interval, int divisor)

--- a/DryWetMidi/Tools/Quantizer/Settings/QuantizingBeyondZeroPolicy.cs
+++ b/DryWetMidi/Tools/Quantizer/Settings/QuantizingBeyondZeroPolicy.cs
@@ -7,7 +7,7 @@
     public enum QuantizingBeyondZeroPolicy
     {
         /// <summary>
-        /// Object will be shrinked due to end time quantization and fixed at zero.
+        /// Object will be shrunk due to end time quantization and fixed at zero.
         /// </summary>
         FixAtZero = 0,
 

--- a/DryWetMidi/Tools/Splitter/MidiFileSlicer.cs
+++ b/DryWetMidi/Tools/Splitter/MidiFileSlicer.cs
@@ -20,9 +20,9 @@ namespace Melanchall.DryWetMidi.Tools
 
             #region Constructor
 
-            public TimedEventsHolder(IEnumerator<TimedEvent> timedEventsEumerator)
+            public TimedEventsHolder(IEnumerator<TimedEvent> timedEventsEnumerator)
             {
-                Enumerator = timedEventsEumerator;
+                Enumerator = timedEventsEnumerator;
                 Enumerator.MoveNext();
             }
 

--- a/Resources/Utilities/ExportBenchmarksResults/ExportBenchmarksResults/Program.cs
+++ b/Resources/Utilities/ExportBenchmarksResults/ExportBenchmarksResults/Program.cs
@@ -56,13 +56,13 @@ namespace ExportBenchmarksResults
                 public string ProcessorName { get; set; }
                 
                 public int PhysicalProcessorCount { get; set; }
-                
+
                 public int PhysicalCoreCount { get; set; }
 
                 public int LogicalCoreCount { get; set; }
 
                 public string RuntimeVersion { get; set; }
-                
+
                 public string Architecture { get; set; }
 
                 public bool HasRyuJit { get; set; }
@@ -75,9 +75,9 @@ namespace ExportBenchmarksResults
                     public double Min { get; set; }
 
                     public double Median { get; set; }
-                    
+
                     public double Mean { get; set; }
-                    
+
                     public double Max { get; set; }
                 }
 
@@ -108,14 +108,14 @@ namespace ExportBenchmarksResults
             var client = InfluxDBClientFactory.Create(url, token.ToCharArray());
             var timestamp = DateTime.UtcNow;
 
-            var filesPathes = Directory.GetFiles(resultsFolderPath, "*.json", SearchOption.AllDirectories);
-            var totalFilesCount = filesPathes.Length;
+            var filesPaths = Directory.GetFiles(resultsFolderPath, "*.json", SearchOption.AllDirectories);
+            var totalFilesCount = filesPaths.Length;
 
             using (var writeApi = client.GetWriteApi())
             {
                 for (var i = 0; i < totalFilesCount; i++)
                 {
-                    var resultsFilePath = filesPathes[i];
+                    var resultsFilePath = filesPaths[i];
                     Console.WriteLine($"Exporting results from file #{i + 1} from {totalFilesCount}: {resultsFilePath}...");
 
                     var json = System.IO.File.ReadAllText(resultsFilePath);


### PR DESCRIPTION
Fixed some spelling mistakes in comments/docs and internal code.
Also consider changing these:
- SysExIncompleted (to SysExIncomplete)
- SysExCompleted (to SysExComplete)
- NOTPERMITTED (to FORBIDDEN)
- Lengthed
Not mistakes, but they sound rather unnatural.