### PR TITLE
Fix SMPTE time divisions not being read/written correctly

### DIFF
--- a/DryWetMidi/Core/TimeDivision/SmpteTimeDivision.cs
+++ b/DryWetMidi/Core/TimeDivision/SmpteTimeDivision.cs
@@ -79,7 +79,7 @@ namespace Melanchall.DryWetMidi.Core
 
         internal override short ToInt16()
         {
-            return (short)-DataTypesUtilities.Combine((byte)Format, Resolution);
+            return (short)DataTypesUtilities.Combine((byte)-(byte)Format, Resolution);
         }
 
         /// <summary>

--- a/DryWetMidi/Core/TimeDivision/TimeDivisionFactory.cs
+++ b/DryWetMidi/Core/TimeDivision/TimeDivisionFactory.cs
@@ -10,8 +10,7 @@ namespace Melanchall.DryWetMidi.Core
         {
             if (division < 0)
             {
-                division = (short)-division;
-                return new SmpteTimeDivision((SmpteFormat)division.GetHead(), division.GetTail());
+                return new SmpteTimeDivision((SmpteFormat)(-division.GetHead()), division.GetTail());
             }
 
             return new TicksPerQuarterNoteTimeDivision(division);


### PR DESCRIPTION
Discovered this while testing a purpose-built MIDI parser using DryWetMidi as a storage model/serializer. Probably went a little overboard with that testing lol, but I found a bug as a result and thought I'd fix it.

Take an SMPTE format of 30 FPS and a resolution of 80 (the example provided in the MIDI file standard):

```cs
new MidiFile() { TimeDivision = new SmpteTimeDivision(SmpteFormat.Thirty, 80) };
```

The expected written value is `E2 50`, but the actual value is `E1 B0`. This happens because DryWetMidi was negating the whole `short` value instead of just the upper byte, which mangles the resolution and causes the format to be 1 lower than it should be (since the two's-compliment +1 step is being done to the lower byte instead of the upper). Only the SMPTE format value should be written negated, the resolution value is positive.

---

One concern I have with this change is compatibility with files written by prior versions of DryWetMidi, but I consider that concern mostly irrelevant when these files most likely don't parse correctly in actual use (unless the target application is also using DryWetMidi).

There could be a read/write option for this, but I'm not familiar enough with the architecture to feel confident in implementing that myself currently. Do let me know if that's something you'd want added.